### PR TITLE
Test multiple seed for random number generators

### DIFF
--- a/Random, multiseed.ipynb
+++ b/Random, multiseed.ipynb
@@ -1,0 +1,107 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "37\n",
+      "235\n",
+      "908\n"
+     ]
+    }
+   ],
+   "source": [
+    "np.random.seed(1)\n",
+    "print(np.random.randint(1000))\n",
+    "print(np.random.randint(1000))\n",
+    "print(np.random.randint(1000))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "168\n",
+      "527\n",
+      "493\n"
+     ]
+    }
+   ],
+   "source": [
+    "np.random.seed(2)\n",
+    "print(np.random.randint(1000))\n",
+    "print(np.random.randint(1000))\n",
+    "print(np.random.randint(1000))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a: 37\n",
+      "b: 168\n",
+      "a: 235\n",
+      "b: 527\n",
+      "a: 908\n",
+      "b: 493\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = np.random.RandomState(1)\n",
+    "b = np.random.RandomState(2)\n",
+    "print(\"a: \"+str(a.randint(1000)))\n",
+    "print(\"b: \"+str(b.randint(1000)))\n",
+    "print(\"a: \"+str(a.randint(1000)))\n",
+    "print(\"b: \"+str(b.randint(1000)))\n",
+    "print(\"a: \"+str(a.randint(1000)))\n",
+    "print(\"b: \"+str(b.randint(1000)))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Like we talked on 09/26, DiffyQ-SimCAD must allow the user to seed each one of their environmental processes independently. If we use numpy.random.<randomizerFunction> directly, this means we need to run every environmental process for all steps and all montecarlo before running the next environmental process. However, using the design in this PoC, we can have one RandomState object per exogenous state and have each one of them be independently seeded.