### PR TITLE
support list of mechsteps instead of dict

### DIFF
--- a/SimCAD/utils/__init__.py
+++ b/SimCAD/utils/__init__.py
@@ -10,8 +10,13 @@ def print_pipe(x):
 def flatten(l):
     return [item for sublist in l for item in sublist]
 
-
+import warnings
 def key_filter(l, keyname):
+    if (type(l)==list):
+        return [v[keyname] for v in l]
+    # Keeping support to dictionaries for backwards compatibility
+    # Should be removed in the future
+    warnings.warn("The use of a dictionary to describe Partial State Update Blocks will be deprecated. Use a list instead.", FutureWarning)
     return [v[keyname] for k, v in l.items()]
 
 


### PR DESCRIPTION
Keeping support to dictionaries so it doesn't break existing configuration files. Issuing warning so that everyone is aware.