### PR TITLE
Change number of nodes on multiproc to 'None'

### DIFF
--- a/cadCAD/engine/__init__.py
+++ b/cadCAD/engine/__init__.py
@@ -43,7 +43,7 @@ def parallelize_simulations(
         Ns: List[int]
     ):
     l = list(zip(simulation_execs, var_dict_list, states_lists, configs_structs, env_processes_list, Ts, Ns))
-    with PPool(len(configs_structs)) as p:
+    with PPool() as p:
         results = p.map(lambda t: t[0](t[1], t[2], t[3], t[4], t[5], t[6]), l)
     return results
 


### PR DESCRIPTION
When running cadCAD for an very large number of configurations on multi_proc mode, the simulations can crash due to the large number of active processes.

Changing the number of nodes to None makes the multiprocessing lib to create them at the same amount than the number of CPUs, avoiding this type of crash.