### PR TITLE
multiprocessing RunitimeError for Windows

### DIFF
--- a/cadCAD/engine/__init__.py
+++ b/cadCAD/engine/__init__.py
@@ -56,6 +56,11 @@ class ExecutionContext:
         if context == 'single_proc':
             self.method = single_proc_exec
         elif context == 'multi_proc':
+            import os
+            if os.name == 'nt': # == windows
+                #For windows: to serialize global varibales in multi-processes
+                import dill
+                dill.settings['recurse'] = True 
             self.method = parallelize_simulations
 
 


### PR DESCRIPTION
**PR concerning errors like ("NameError: name 'np' is not defined") when using multiprocess exec mode on windows:**
Linked to #104 & #93

Is it convenient to add the following "workaround code" to \cadCAD\_init_.py file to fixe the issue?

```
name = "cadCAD"
configs = []

#added code
import os
if os.name == 'nt': 
    import dill
    dill.settings['recurse'] = True 
This fixed the issue.
```

or should we only add the code to \cadCAD\engine\_init_.py] file to fixe the issue?

```
class ExecutionContext:
    def __init__(self, context: str = ExecutionMode.multi_proc) -> None:
...
        elif context == 'multi_proc':
           #add code here? 
           import os
           if os.name == 'nt': 
               import dill
               dill.settings['recurse'] = True 
            self.method = parallelize_simulations
```

to limit the setting to multiprocess exec mode and reduce potential side effects. Indeed, although this seems to be a stable workaround for windows, there are some comments (see [https://github.com/uqfoundation/dill/issues/115]) that are mitigated about the solution.

There are 2 other less convincing alternatives for our issue:
1 - To declare the missing global variables (which are not correctly serialized without dill.settings['recurse'] = True) at the function level (see [https://github.com/uqfoundation/multiprocess/issues/6]) => could be less practical, since this requires to re-declare global variables locally...
2 - to use cloudpickle instead of dill (see [https://github.com/apache/airflow/issues/7870]), => no idea on the impact of the migration

Regards,