### PR TITLE
Run test suite rather than explicit test files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,8 @@ jobs:
       - python/save-cache
       - run: pip install pandas cadcad
       - run:
-          command: python testing/tests/param_sweep.py
-          name: Param Sweep
-      - run:
-          command: python testing/tests/policy_aggregation.py
-          name: Policy Aggregation
+          command: python -m unittest discover -s testing/tests -p "*_test.py"
+          name: Test Suite
 
 workflows:
   main:


### PR DESCRIPTION
Use test discovery to run any test files which have names ending in `_test.py` inside the `/testing/tests` directory. This PR does not update any test files to use this naming convention and is only a configuration update.