### PR TITLE
Add version to execution logs

### DIFF
--- a/cadCAD/utils/execution.py
+++ b/cadCAD/utils/execution.py
@@ -1,8 +1,10 @@
 from cadCAD import logo
+from setup import version
 
 
 def print_exec_info(exec_context, configs):
     print(logo)
+    print(f'cadCAD Version: {version}')
     print(f'Execution Mode: {exec_context}')
     print(f'Configuration Count: {len(configs)}')
     first_sim = configs[0].sim_config

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,11 @@ under various conditions. Support for A/B testing policies, Monte Carlo analysis
 provided.
 """
 
-setup(name='cadCAD',
-      version='0.4.23',
+name = "cadCAD"
+version = "0.4.23"
+
+setup(name=name,
+      version=version,
       description=short_description,
       long_description=long_description,
       url='https://github.com/cadCAD-org/cadCAD',


### PR DESCRIPTION
Changes:
- [x] Add cadCAD version to the execution logs for clarification.