### PR TITLE
pass `params` as a dict into policy and state update functions

### DIFF
--- a/cadCAD/engine/simulation.py
+++ b/cadCAD/engine/simulation.py
@@ -102,7 +102,7 @@ class Executor:
     # mech_step
     def partial_state_update(
         self,
-        sweep_dict: Dict[str, List[Any]],
+        sweep_dict: Dict[str, Any],
         sub_step: int,
         sL,
         sH,


### PR DESCRIPTION
In my code, system parameters are passed (as `params`) into policy and state update functions as a list with a single dictionary item. For example, `params` might look like:

```python
[
  {
    'a': 1,
    'b': 2,
    ...
  }
]
```

This feels unintuitive, and necessitates something like `params, = params` (shorthand for `params = params[0]`) at the top of each function.

Separately, this issue was discussed [here](https://github.com/cadCAD-org/cadCAD/issues/175).

This PR may fixes this issue for me, in `EXEC_MODE.single_proc` mode, version `0.4.28`.

Before considering a merge, a discussion should be had about whether this is expected to work across the gamut of execution modes.