### PR TITLE
fix cadCAD for py=3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog:
+
+
+### February 15, 2023
+* **Fixes:** 
+    - Package has been cleaned-up for working with Python 3.10
 ### September 28, 2021
 #### New Features:
 * **ver. ≥ `0.4.28`:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,12 @@
 -i https://pypi.org/simple
 
-matplotlib==3.3.2
-networkx==2.5
-parameterized==0.7.4
-plotly==4.10.0
-pytest==6.0.2
-scikit-learn==0.23.2
-scipy>=1.5.2
-seaborn==0.11.0
-tabulate==0.8.7
-xarray==0.16.0
-wheel==0.36.2
-pandas==1.1.5
-fn==0.4.3
-funcy==1.16
-dill==0.3.4
-pathos==0.2.8
-numpy==1.22.0
-pytz==2021.1
-six>=1.11.0
+parameterized>=0.7.4
+pytest>=6.0.2
+tabulate>=0.8.7
+wheel>=0.36.2
+pandas>=1.1.5
+funcy>=1.16
+dill>=0.3.4
+pathos>=0.2.8
+numpy>=1.22.0
+pytz>=2021.1

--- a/setup.py
+++ b/setup.py
@@ -34,13 +34,11 @@ setup(name=name,
       packages=find_packages(),
       install_requires=[
             "pandas",
-            "fn",
             "funcy",
             "dill",
             "pathos",
             "numpy",
-            "pytz",
-            "six"
-      ],
+            "pytz"     
+             ],
       python_requires='>=3.6.13'
 )


### PR DESCRIPTION
This PR does the following:

- Remove all un-used dependencies on the repo, including `funcy`, which was creating an imcompatibility with `Python>=3.10`
- Use the Larger Than operator rather than the Equal to operator on `requirements.txt` in order to future-proof it