### PR TITLE
Update setup.py to include tqdm package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setup(
     author_email="info@block.science",
     license="LICENSE.txt",
     packages=find_packages(),
-    install_requires=["pandas", "funcy", "dill", "pathos", "numpy", "pytz", "six"],
+    install_requires=["pandas", "funcy", "dill", "pathos", "numpy", "pytz", "six", "tqdm"],
     python_requires=">=3.9.0",
 )


### PR DESCRIPTION
The `tqdm` package was recently added as a dependency of cadCAD, but wasn't included in the setup.py file. When installed from PyPi, this results in the error `ModuleNotFoundError: No module named 'tqdm'`. This error does not occur in the tests because the GitHub workflow installs dependencies from the `requirements.txt` file.