### PR TITLE
Debug M dictionairy unpacking in utils.

### DIFF
--- a/cadCAD/configuration/utils/__init__.py
+++ b/cadCAD/configuration/utils/__init__.py
@@ -186,7 +186,7 @@ def config_sim(config_dict: ConfigurationDict):
                 raise Exception('When sweeping, `M` list lengths should either be 1 and/or equal. More than two distinct lengths are not allowed')
             elif (distinct_param_value_lengths == 1) and (0 in param_values_length_set):
                 return config_dict
-            elif (1 in param_values_length_set):
+            elif (distinct_param_value_lengths == 1) or (1 in param_values_length_set):
                 return [{**config_dict, "M": M} 
 
                         for M in flatten_tabulated_dict(tabulate_dict(params))]

--- a/cadCAD/tools/execution/easy_run.py
+++ b/cadCAD/tools/execution/easy_run.py
@@ -41,6 +41,7 @@ def easy_run(
     assign_params: Union[bool, set] = True,
     drop_substeps=True,
     exec_mode='local',
+    deepcopy_off=False,
 ) -> pd.DataFrame:
     """
     Run cadCAD simulations without headaches.
@@ -64,7 +65,7 @@ def easy_run(
         _exec_mode = ExecutionMode().local_mode
     elif exec_mode == 'single':
         _exec_mode = ExecutionMode().single_mode
-    exec_context = ExecutionContext(_exec_mode)
+    exec_context = ExecutionContext(_exec_mode, additional_objs={'deepcopy_off': deepcopy_off})
     executor = Executor(exec_context=exec_context, configs=configs)
 
     # Execute the cadCAD experiment

--- a/testing/tools/test_tools.py
+++ b/testing/tools/test_tools.py
@@ -1,0 +1,66 @@
+from cadCAD.tools.execution import easy_run
+
+# def test_empty_easy_run():
+#     state_variables = {
+#     }
+#
+#     params = {
+#     }
+#
+#     psubs = [
+#         {
+#             'policies': {},
+#             'variables': {},
+#         },
+#     ]
+#
+#     N_timesteps = 2
+#
+#     N_samples = 1
+#
+#     results = easy_run(
+#         state_variables,
+#         params,
+#         psubs,
+#         N_timesteps,
+#         N_samples,
+#     )
+#     print(results)
+
+
+
+def test_easy_run():
+    state_variables = {
+        'a':0.5,
+    }
+
+    params = {
+        'c':[1, 2],
+        'd':[1, 2],
+    }
+
+    def p(params, substep, state_history, previous_state):
+        a_delta = 1 - params['c'] * previous_state['a']
+        return {'a_delta': a_delta}
+
+    def s(params, substep, state_history, previous_state, policy_input):
+        return 'a', previous_state['a'] + policy_input['a_delta']
+
+    psubs = [
+        {
+            'policies': {'p': p},
+            'variables': {'a': s},
+        },
+    ]
+
+    N_timesteps = 2
+
+    N_samples = 1
+
+    results = easy_run(
+        state_variables,
+        params,
+        psubs,
+        N_timesteps,
+        N_samples,
+    )


### PR DESCRIPTION
1. Add support for the case where all system params have same length that is not 1. For example: 

```
    params = {
        'c':[1, 2],
        'd':[1, 2],
    }
```

2. Add test for easy_run